### PR TITLE
GH12: Grab clipboard image & upload file command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
         "osascript",
         "windowstyle",
         "xclip"
-    ]
+    ],
+    "clipImg.storageAccountName": "clipimg"
 }

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ This extension brings support for [ClipImg](https://github.com/gep13-oss/clipimg
 
 ## What is ClipImg?
 
-Provide more details here...
+ClipImg will let you take an image from your clipboard and automatically uploaded it to Azure blob storage, and the markdown needed to display that image inserted to the editor.
+
+![Example usage ClipImg](https://clipimg.blob.core.windows.net/clipimg-vscode/2020/09/06/056f020b-dbf5-4ce7-8fee-60364f53e0c4.gif?sp=r&st=2020-09-06T15:34:59Z&se=2020-09-07T15:34:59Z&sv=2019-12-12&sr=b&sig=NXyOB4U9yMsU8si1L8D%2Bptgb6GBz8jtDOajqN%2FoQflQ%3D)
 
 ## Commands
 
 The ClipImg Visual Studio Code provides the following commands:
 
-* `TODO`
-
-## Resources
-
-Short YouTube videos of each of the releases of this extension can be found in this [playlist]().
+* Paste Image as Markdown
+    * MacOS <kbd>Ctrl</kbd> + <kbd>Cmd</kbd> + <kbd>v</kbd>
+    * Linux / Windows <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>v</kbd>
 
 ## Installation
 
@@ -34,16 +34,40 @@ You can either install this extension in the normal way, or you can choose to in
 choco install clipimg-vscode
 ```
 
-## Documentation
+## Usage
 
-You can find the documentation that is available for this project [here](https://gep13.github.io/clipimg-vscode/).
+1. Have an image in the clipboard
+1. Invoke command
+    - Pick `Paste Image as Markdown` from command palette!<br/>
+    ![Paste Image as Markdown in Command Palette](https://clipimg.blob.core.windows.net/clipimg-vscode/2020/09/06/1e3da757-6c35-cfd1-79e5-26df02236946.png?sv=2019-12-12&st=2020-09-05T14%3A51%3A52Z&se=2030-09-06T14%3A51%3A52Z&sr=b&sp=r&sig=vh4TxVmnFcoQfR4QVAHQ%2B2d1E4AciBXDVljZRpEUWAo%3D)<br/>or
+    - Use keyboard shortcut
+        - MacOS <kbd>Ctrl</kbd> + <kbd>Cmd</kbd> + <kbd>v</kbd>
+        - Linux / Windows <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>v</kbd>
+1. Enter image alt text<br/>![Image alt text input](https://clipimg.blob.core.windows.net/clipimg-vscode/2020/09/06/9a2251d7-08cf-72e5-d158-4cc5676add06.png?sv=2019-12-12&st=2020-09-05T14%3A57%3A25Z&se=2030-09-06T14%3A57%3A25Z&sr=b&sp=r&sig=POT%2Bd0dfrAZxewCNhq8WUUj9xi3Uh23K170i2QcKip4%3D)
+1. The first time you execute the command in a workspace you'll be asked for the Azure storage account name to use<br/>
+![Azure storage account input](https://clipimg.blob.core.windows.net/clipimg-vscode/2020/09/06/8b160ae5-e702-a119-86e5-0d1324f4140c.png?sv=2019-12-12&st=2020-09-05T15%3A00%3A26Z&se=2030-09-06T15%3A00%3A26Z&sr=b&sp=r&sig=xESopPy9X9hGidHH4BGD4NPEn4%2BSYbKSqvJEifpmX8o%3D)<br/>
+this is then stored in the current workspace settings.
+1. The first time you use a specific storage account on your computer it'll ask for the Azure storage account key.</br>
+![Azure storage account key input](https://clipimg.blob.core.windows.net/clipimg-vscode/2020/09/06/911030b1-7b7a-a642-5aad-ac32f512af0e.png?sv=2019-12-12&st=2020-09-05T15%3A04%3A43Z&se=2030-09-06T15%3A04%3A43Z&sr=b&sp=r&sig=WgECpUxYCyaDf%2FjXrOHDEuxG3a46QLwaccvCJkajiNw%3D)
+the key is stored in
+    - Windows: Credential manager
+    - MacOS: Keychain
+    - Linux: Secret Service API/libsecret
+1. Image is uploaded and markdown for the newly uploaded image is inserted into the editor</br>
+![Example image markdown](https://clipimg.blob.core.windows.net/clipimg-vscode/2020/09/06/5319cd97-a3a9-17e9-86d4-3a21182ca5d0.png?sv=2019-12-12&st=2020-09-05T15%3A22%3A24Z&se=2030-09-06T15%3A22%3A24Z&sr=b&sp=r&sig=jwSUpS89MJa%2BvQ5GOQR%2BQ%2BcMI8MyUJq1tvBK83qIK30%3D)
+
+### Requirements
+
+* Azure Storage Account
+    - Name
+    - Key
+    ![Azure portal storage account name and key](https://clipimg.blob.core.windows.net/clipimg-vscode/2020/09/06/b9c20692-3eb1-e630-bd03-89e95c902076.png?sv=2019-12-12&st=2020-09-05T16%3A02%3A30Z&se=2030-09-06T16%3A02%3A30Z&sr=b&sp=r&sig=aPEl4ploTM%2Bdy6t73n2eH8hBbWWRl9BNS09D0Y2%2FXlI%3D)
+* Linux
+    - xclip
+    - libsecret
 
 ## Contributing
 
 If you would like to see any features added for this VS Code Extension, feel free to raise an [issue](https://github.com/gep13-oss/clipimg-vscode/issues), and if possible, a follow up pull request.
 
 You can also join in the Gitter Chat [![Join the chat at https://gitter.im/gep13-oss/community](https://badges.gitter.im/gep13-oss/community.svg)](https://gitter.im/gep13-oss/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
-## Releases
-
-To find out what was released in each version of this extension, check ou

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,149 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@azure/abort-controller": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.1.tgz",
+			"integrity": "sha512-wP2Jw6uPp8DEDy0n4KNidvwzDjyVV2xnycEIq7nPzj1rHyb/r+t3OPeNT1INZePP2wy5ZqlwyuyOMTi0ePyY1A==",
+			"requires": {
+				"tslib": "^1.9.3"
+			}
+		},
+		"@azure/core-asynciterator-polyfill": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+			"integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+		},
+		"@azure/core-auth": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.1.3.tgz",
+			"integrity": "sha512-A4xigW0YZZpkj1zK7dKuzbBpGwnhEcRk6WWuIshdHC32raR3EQ1j6VA9XZqE+RFsUgH6OAmIK5BWIz+mZjnd6Q==",
+			"requires": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-tracing": "1.0.0-preview.8",
+				"@opentelemetry/api": "^0.6.1",
+				"tslib": "^2.0.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+				}
+			}
+		},
+		"@azure/core-http": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.1.6.tgz",
+			"integrity": "sha512-/C+qNzhwlLKt0F6SjaBEyY2pwZvwL2LviyS5PHlCh77qWuTF1sETmYAINM88BCN+kke+UlECK4YOQaAjJwyHvQ==",
+			"requires": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-auth": "^1.1.3",
+				"@azure/core-tracing": "1.0.0-preview.9",
+				"@azure/logger": "^1.0.0",
+				"@opentelemetry/api": "^0.10.2",
+				"@types/node-fetch": "^2.5.0",
+				"@types/tunnel": "^0.0.1",
+				"form-data": "^3.0.0",
+				"node-fetch": "^2.6.0",
+				"process": "^0.11.10",
+				"tough-cookie": "^4.0.0",
+				"tslib": "^2.0.0",
+				"tunnel": "^0.0.6",
+				"uuid": "^8.1.0",
+				"xml2js": "^0.4.19"
+			},
+			"dependencies": {
+				"@azure/core-tracing": {
+					"version": "1.0.0-preview.9",
+					"resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.9.tgz",
+					"integrity": "sha512-zczolCLJ5QG42AEPQ+Qg9SRYNUyB+yZ5dzof4YEc+dyWczO9G2sBqbAjLB7IqrsdHN2apkiB2oXeDKCsq48jug==",
+					"requires": {
+						"@opencensus/web-types": "0.0.7",
+						"@opentelemetry/api": "^0.10.2",
+						"tslib": "^2.0.0"
+					}
+				},
+				"@opentelemetry/api": {
+					"version": "0.10.2",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.10.2.tgz",
+					"integrity": "sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==",
+					"requires": {
+						"@opentelemetry/context-base": "^0.10.2"
+					}
+				},
+				"@opentelemetry/context-base": {
+					"version": "0.10.2",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.10.2.tgz",
+					"integrity": "sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw=="
+				},
+				"tslib": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+				}
+			}
+		},
+		"@azure/core-lro": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.2.tgz",
+			"integrity": "sha512-Yr0JD7GKryOmbcb5wHCQoQ4KCcH5QJWRNorofid+UvudLaxnbCfvKh/cUfQsGUqRjO9L/Bw4X7FP824DcHdMxw==",
+			"requires": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-http": "^1.1.1",
+				"events": "^3.0.0",
+				"tslib": "^1.10.0"
+			}
+		},
+		"@azure/core-paging": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.1.tgz",
+			"integrity": "sha512-hqEJBEGKan4YdOaL9ZG/GRG6PXaFd/Wb3SSjQW4LWotZzgl6xqG00h6wmkrpd2NNkbBkD1erLHBO3lPHApv+iQ==",
+			"requires": {
+				"@azure/core-asynciterator-polyfill": "^1.0.0"
+			}
+		},
+		"@azure/core-tracing": {
+			"version": "1.0.0-preview.8",
+			"resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.8.tgz",
+			"integrity": "sha512-ZKUpCd7Dlyfn7bdc+/zC/sf0aRIaNQMDuSj2RhYRFe3p70hVAnYGp3TX4cnG2yoEALp/LTj/XnZGQ8Xzf6Ja/Q==",
+			"requires": {
+				"@opencensus/web-types": "0.0.7",
+				"@opentelemetry/api": "^0.6.1",
+				"tslib": "^1.10.0"
+			}
+		},
+		"@azure/logger": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.0.tgz",
+			"integrity": "sha512-g2qLDgvmhyIxR3JVS8N67CyIOeFRKQlX/llxYJQr1OSGQqM3HTpVP8MjmjcEKbL/OIt2N9C9UFaNQuKOw1laOA==",
+			"requires": {
+				"tslib": "^1.9.3"
+			}
+		},
+		"@azure/storage-blob": {
+			"version": "12.2.0-preview.1",
+			"resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.2.0-preview.1.tgz",
+			"integrity": "sha512-4igL7EPn0pxDy7uUBTnx/kxqWK3ZXO7HkIEx919m+rCXLsCQzvLrDd7YGn8VI/bhO2JrPTM8vxPu7bNYC4aEwQ==",
+			"requires": {
+				"@azure/abort-controller": "^1.0.0",
+				"@azure/core-http": "^1.1.1",
+				"@azure/core-lro": "^1.0.2",
+				"@azure/core-paging": "^1.1.1",
+				"@azure/core-tracing": "1.0.0-preview.8",
+				"@azure/logger": "^1.0.0",
+				"@opentelemetry/api": "^0.6.1",
+				"events": "^3.0.0",
+				"tslib": "^2.0.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+					"integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+				}
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
@@ -29,6 +172,24 @@
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
+		},
+		"@opencensus/web-types": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+			"integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
+		},
+		"@opentelemetry/api": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.6.1.tgz",
+			"integrity": "sha512-wpufGZa7tTxw7eAsjXJtiyIQ42IWQdX9iUQp7ACJcKo1hCtuhLU+K2Nv1U6oRwT1oAlZTE6m4CgWKZBhOiau3Q==",
+			"requires": {
+				"@opentelemetry/context-base": "^0.6.1"
+			}
+		},
+		"@opentelemetry/context-base": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.6.1.tgz",
+			"integrity": "sha512-5bHhlTBBq82ti3qPT15TRxkYTFPPQWbnkkQkmHPtqiS1XcTB69cEKd3Jm7Cfi/vkPoyxapmePE9tyA7EzLt8SQ=="
 		},
 		"@types/color-name": {
 			"version": "1.1.1",
@@ -61,8 +222,24 @@
 		"@types/node": {
 			"version": "14.6.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
-			"integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==",
-			"dev": true
+			"integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ=="
+		},
+		"@types/node-fetch": {
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+			"integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+			"requires": {
+				"@types/node": "*",
+				"form-data": "^3.0.0"
+			}
+		},
+		"@types/tunnel": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+			"integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/vscode": {
 			"version": "1.48.0",
@@ -88,8 +265,7 @@
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-			"dev": true
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -108,6 +284,20 @@
 			"requires": {
 				"normalize-path": "^3.0.0",
 				"picomatch": "^2.0.4"
+			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+		},
+		"are-we-there-yet": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"requires": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
 			}
 		},
 		"argparse": {
@@ -131,17 +321,49 @@
 				"is-string": "^1.0.4"
 			}
 		},
+		"asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true
 		},
+		"base64-js": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
 		"binary-extensions": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
 			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
 			"dev": true
+		},
+		"bl": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+			"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+			"requires": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -167,6 +389,15 @@
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
+		},
+		"buffer": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+			"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+			"requires": {
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
+			}
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
@@ -207,6 +438,11 @@
 				"readdirp": "~3.4.0"
 			}
 		},
+		"chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+		},
 		"cliui": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -246,6 +482,11 @@
 				}
 			}
 		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -261,6 +502,14 @@
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
 		},
+		"combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"requires": {
+				"delayed-stream": "~1.0.0"
+			}
+		},
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -272,6 +521,16 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true
+		},
+		"console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"debug": {
 			"version": "3.1.0",
@@ -288,6 +547,19 @@
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 			"dev": true
 		},
+		"decompress-response": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+			"requires": {
+				"mimic-response": "^2.0.0"
+			}
+		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+		},
 		"define-properties": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -296,6 +568,21 @@
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
+		},
+		"delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+		},
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+		},
+		"detect-libc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"diff": {
 			"version": "4.0.2",
@@ -308,6 +595,14 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
 			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 			"dev": true
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"requires": {
+				"once": "^1.4.0"
+			}
 		},
 		"es-abstract": {
 			"version": "1.17.6",
@@ -387,6 +682,16 @@
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
 		},
+		"events": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+			"integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
+		},
+		"expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -415,6 +720,21 @@
 				"is-buffer": "~2.0.3"
 			}
 		},
+		"form-data": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+			"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -434,11 +754,64 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
+		"gauge": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"requires": {
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
 		"get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
+		},
+		"github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glob": {
 			"version": "7.1.6",
@@ -495,6 +868,11 @@
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
 			"dev": true
 		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -521,6 +899,11 @@
 				"debug": "^3.1.0"
 			}
 		},
+		"ieee754": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+		},
 		"inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -534,8 +917,12 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inversify": {
 			"version": "5.0.1",
@@ -584,8 +971,7 @@
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-glob": {
 			"version": "4.0.1",
@@ -688,6 +1074,15 @@
 				"esprima": "^4.0.0"
 			}
 		},
+		"keytar": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/keytar/-/keytar-6.0.1.tgz",
+			"integrity": "sha512-1Ihpf2tdM3sLwGMkYHXYhVC/hx5BDR7CWFL4IrBA3IDZo0xHhS2nM+tU9Y+u/U7okNfbVkwmKsieLkcWRMh93g==",
+			"requires": {
+				"node-addon-api": "^3.0.0",
+				"prebuild-install": "5.3.4"
+			}
+		},
 		"locate-path": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -758,6 +1153,24 @@
 				}
 			}
 		},
+		"mime-db": {
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+		},
+		"mime-types": {
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"requires": {
+				"mime-db": "1.44.0"
+			}
+		},
+		"mimic-response": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -770,17 +1183,20 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"mkdirp": {
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
+		},
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
 		"mocha": {
 			"version": "8.1.3",
@@ -859,11 +1275,60 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
+		"napi-build-utils": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+		},
+		"node-abi": {
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
+			"integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+			"requires": {
+				"semver": "^5.4.1"
+			}
+		},
+		"node-addon-api": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.0.tgz",
+			"integrity": "sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg=="
+		},
+		"node-fetch": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+			"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+		},
+		"noop-logger": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true
+		},
+		"npmlog": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"requires": {
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-inspect": {
 			"version": "1.8.0",
@@ -893,7 +1358,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -946,6 +1410,38 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
+		"prebuild-install": {
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.4.tgz",
+			"integrity": "sha512-AkKN+pf4fSEihjapLEEj8n85YIw/tN6BQqkhzbDc0RvEZGdkpJBGMUYx66AAMcPG2KzmPQS7Cm16an4HVBRRMA==",
+			"requires": {
+				"detect-libc": "^1.0.3",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp": "^0.5.1",
+				"napi-build-utils": "^1.0.1",
+				"node-abi": "^2.7.0",
+				"noop-logger": "^0.1.1",
+				"npmlog": "^4.0.1",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^3.0.3",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0",
+				"which-pm-runs": "^1.0.0"
+			}
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"promise.allsettled": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
@@ -959,6 +1455,25 @@
 				"iterate-value": "^1.0.0"
 			}
 		},
+		"psl": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"punycode": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -966,6 +1481,50 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
+			}
+		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+				}
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
 			}
 		},
 		"readdirp": {
@@ -1015,14 +1574,17 @@
 		"safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"serialize-javascript": {
 			"version": "4.0.0",
@@ -1036,8 +1598,27 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+		},
+		"signal-exit": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+		},
+		"simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+		},
+		"simple-get": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+			"requires": {
+				"decompress-response": "^4.2.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
@@ -1049,7 +1630,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "^2.0.0",
 				"strip-ansi": "^4.0.0"
@@ -1075,11 +1655,25 @@
 				"es-abstract": "^1.17.5"
 			}
 		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
 		"strip-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^3.0.0"
 			}
@@ -1099,6 +1693,41 @@
 				"has-flag": "^3.0.0"
 			}
 		},
+		"tar-fs": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+			"integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.0.0"
+			}
+		},
+		"tar-stream": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+			"integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
+			"requires": {
+				"bl": "^4.0.1",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1108,11 +1737,20 @@
 				"is-number": "^7.0.0"
 			}
 		},
+		"tough-cookie": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+			"integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+			"requires": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.1.2"
+			}
+		},
 		"tslib": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
-			"dev": true
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
 		},
 		"tslint": {
 			"version": "6.1.3",
@@ -1144,11 +1782,39 @@
 				"tslib": "^1.8.1"
 			}
 		},
+		"tunnel": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+			"integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+		},
+		"tunnel-agent": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
 		"typescript": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
 			"integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
 			"dev": true
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+			"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
 		},
 		"vscode-test": {
 			"version": "1.4.0",
@@ -1176,11 +1842,15 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
+		"which-pm-runs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}
@@ -1233,8 +1903,21 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xml2js": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+			"integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			}
+		},
+		"xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
 		},
 		"y18n": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,35 @@
 				"command": "extension.clipImg",
 				"title": "Paste Image as Markdown"
 			}
-		]
+		],
+		"keybindings": [
+			{
+				"command": "extension.clipImg",
+				"key": "ctrl+alt+v",
+				"mac": "ctrl+cmd+v"
+			}
+		],
+		"configuration": {
+			"title": "ClipImg",
+			"properties": {
+				"clipImg.storageAccountName": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": null,
+					"description": "Specifies the storage account name to use."
+				},
+				"clipImg.storageAccountContainer": {
+					"type": [
+						"string",
+						"null"
+					],
+					"default": "clipimg-vscode",
+					"description": "Specifies the storage account container to use."
+				}
+			}
+		}
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
@@ -53,8 +81,10 @@
 		"vscode-test": "^1.4.0"
 	},
 	"dependencies": {
+		"@azure/storage-blob": "^12.2.0-preview.1",
 		"guid-typescript": "^1.0.9",
 		"inversify": "^5.0.1",
+		"keytar": "^6.0.1",
 		"reflect-metadata": "^0.1.13"
 	}
 }

--- a/src/blobstorage-service.ts
+++ b/src/blobstorage-service.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+import { injectable, inject } from 'inversify';
+import TYPES from './types';
+import { MessageService } from './message-service';
+import { BlobServiceClient, StorageSharedKeyCredential, generateBlobSASQueryParameters, ContainerSASPermissions } from '@azure/storage-blob';
+import { setPassword, getPassword } from 'keytar';
+import { error } from 'console';
+
+@injectable()
+export class BlobStorageService {
+    constructor(
+        @inject(TYPES.MessageService) private messageService: MessageService,
+      ){}
+
+  async uploadStorageBlockBlob(imageFileName: string,
+        imageFullFileName: string) {
+
+    let config = vscode.workspace.getConfiguration('clipImg');
+    let { blobServiceClient, storageSharedKeyCredential } = await this.getBlobServiceClient(config);
+
+    let container = blobServiceClient.getContainerClient(config.get('storageAccountContainer', 'clipimg-vscode'));
+    await container.createIfNotExists();
+    let now = new Date();
+    let blobName = `${now.getFullYear()}/${(now.getMonth() + 1).toString().padStart(2, '0')}/${now.getDate().toString().padStart(2, '0')}/${imageFileName}`;
+    let blobClient = container.getBlockBlobClient(blobName);
+
+    await blobClient.uploadFile(imageFullFileName);
+    let startsOn = new Date();
+    let expiresOn = new Date();
+    startsOn.setDate(startsOn.getDate() - 1);
+    expiresOn.setFullYear(expiresOn.getFullYear() + 10);
+
+    let sasQuery = generateBlobSASQueryParameters(
+      {
+        containerName: container.containerName,
+        blobName: blobName,
+        permissions: ContainerSASPermissions.parse('r'),
+        startsOn: startsOn,
+        expiresOn: expiresOn
+      },
+      storageSharedKeyCredential
+    );
+
+    return `${decodeURIComponent(blobClient.url)}?${sasQuery}`;
+  }
+
+  private async getBlobServiceClient(config : vscode.WorkspaceConfiguration) {
+    let { storageAccountName, storageAccountKey, storageAccountUrl } = await this.getStorageAccount(config);
+
+    let storageSharedKeyCredential = new StorageSharedKeyCredential(storageAccountName,
+      storageAccountKey
+    );
+
+    let blobServiceClient = new BlobServiceClient(
+      storageAccountUrl,
+      storageSharedKeyCredential
+    );
+    return { blobServiceClient, storageSharedKeyCredential };
+  }
+
+  private async getStorageAccount(config: vscode.WorkspaceConfiguration) {
+    let storageAccountName = await this.getStorageAccountName(config);
+    let storageAccountUrl = `https://${storageAccountName}.blob.core.windows.net`;
+    let storageAccountKey = await this.getStorageAccountKey(storageAccountUrl, storageAccountName);
+    return { storageAccountName, storageAccountKey, storageAccountUrl };
+  }
+
+  private async getStorageAccountKey(storageAccountUrl: string, storageAccountName: string) {
+    let storageAccountKey = (await getPassword(storageAccountUrl, storageAccountName)) || '';
+
+    if (storageAccountKey.length <= 0) {
+      storageAccountKey = await this.messageService.showInput('Provide storage account key', '', true) || '';
+
+      if (storageAccountKey.length <= 0) {
+
+        throw error('Failed to fetch storage account key.');
+      }
+      await setPassword(storageAccountUrl, storageAccountName, storageAccountKey);
+    }
+    return storageAccountKey;
+  }
+
+  private async getStorageAccountName(config: vscode.WorkspaceConfiguration) {
+    let storageAccountName = config.get('storageAccountName', '') || '';
+
+    if (storageAccountName.length <= 0) {
+      storageAccountName = await this.messageService.showInput('Provide storage account name', '') || '';
+
+      if (storageAccountName.length <= 0) {
+        throw error('Failed to fetch storage account name.');
+      }
+
+      await config.update('storageAccountName', storageAccountName, vscode.ConfigurationTarget.Workspace);
+    }
+    return storageAccountName;
+  }
+}

--- a/src/commands/clipimg-command.ts
+++ b/src/commands/clipimg-command.ts
@@ -4,56 +4,83 @@ import { ICommand } from "./icommand";
 import { MessageService } from '../message-service';
 import TYPES from '../types';
 import { ClipboardService } from '../clipboard-service';
+import { BlobStorageService } from '../blobstorage-service';
 import * as path from 'path';
 import { Guid } from "guid-typescript";
+import { promises as fs } from 'fs';
 
 @injectable()
 export class ClipImgCommand implements ICommand {
 
   constructor(
     @inject(TYPES.MessageService) private messageService: MessageService,
-    @inject(TYPES.ClipboardService) private clipBoardService: ClipboardService
-  ) {}
+    @inject(TYPES.ClipboardService) private clipBoardService: ClipboardService,
+    @inject(TYPES.BlobStorageService) private blobStorageService: BlobStorageService
+  ) {
+  }
 
   get id() { return "extension.clipImg"; }
 
   async execute(...args: any[]) {
-    let currentFileName = vscode.window.activeTextEditor?.document.fileName;
-    if (!currentFileName) {
-      this.messageService.showError("Failed to fetch current file path.");
-      return;
-    }
+    try
+    {
+      let currentFileName = vscode.window.activeTextEditor?.document.fileName;
 
-    let currentFolder =  path.dirname(currentFileName);
-    let imageFileName = `${Guid.create()}.png`;
-    let imageFullFileName = path.join(currentFolder, imageFileName);
-
-    let altText = await this.messageService.showInput("Provide description for image", "");
-    
-    this.clipBoardService.getContentsAndSaveToFile(imageFullFileName, (imagePath, imagePathReturnByScript) => {
-      let editor = vscode.window.activeTextEditor;
-      if(!editor) {
-        this.messageService.showError("No active editor text window found.");
+      if (!currentFileName) {
+        this.messageService.showError("Failed to fetch current file path.");
         return;
       }
-  
-      let selection = editor.selection;
-  
-      editor.edit(edit => {
-        let current = selection;
-        let prefix = '![';
-        let middle = '](';
-        let suffix = ')';
 
-        let imageFilePath = `${prefix}${altText}${middle}${imageFileName}${suffix}`;
-        if(current.isEmpty) {
-          edit.insert(current.start, imageFilePath);
-        } else {
-          edit.replace(current, imageFilePath);
+      let currentFolder =  path.dirname(currentFileName);
+      let imageFileName = `${Guid.create()}.png`;
+      let imageFullFileName = path.join(currentFolder, imageFileName);
+
+      let altText = await this.messageService.showInput("Provide description for image", "");
+
+      this.clipBoardService.getContentsAndSaveToFile(imageFullFileName, async (imagePath, imagePathReturnByScript)  => {
+        try
+        {
+          let editor = vscode.window.activeTextEditor;
+          if(!editor) {
+            this.messageService.showError("No active editor text window found.");
+            return;
+          }
+
+          let uri = await this.blobStorageService.uploadStorageBlockBlob(imageFileName, imageFullFileName);
+
+          await fs.unlink(imageFullFileName);
+
+          this.insertImageMarkdown(editor, altText, uri);
         }
-      });
-  
-    },
-    (_, error)=>this.messageService.showError(error));
+        catch(e)
+        {
+          this.messageService.showError(e);
+        }
+      },
+      (_, error)=>this.messageService.showError(error));
+    }
+    catch(e)
+    {
+      this.messageService.showError(e);
+    }
+  }
+
+  private insertImageMarkdown(editor: vscode.TextEditor, altText: any, uri: string) {
+    let selection = editor.selection;
+
+    editor.edit(edit => {
+      let current = selection;
+      let prefix = '![';
+      let middle = '](';
+      let suffix = ')';
+
+      let imageFilePath = `${prefix}${altText}${middle}${uri}${suffix}`;
+      if (current.isEmpty) {
+        edit.insert(current.start, imageFilePath);
+      }
+      else {
+        edit.replace(current, imageFilePath);
+      }
+    });
   }
 }

--- a/src/commands/icommand.d.ts
+++ b/src/commands/icommand.d.ts
@@ -1,4 +1,4 @@
 export interface ICommand {
   id: string;
-  execute(...args: any[]): any;
+  execute(...args: any[]): Promise<void>;
 }

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -8,11 +8,13 @@ import { ClipImgCommand } from './commands/clipimg-command';
 import { MessageService } from './message-service';
 import { ClipboardService } from './clipboard-service';
 import { FileSystemService } from './filesystem-service';
+import { BlobStorageService } from './blobstorage-service';
 
 const container = new Container();
 container.bind(TYPES.MessageService).to(MessageService).inSingletonScope();
 container.bind(TYPES.ClipboardService).to(ClipboardService).inSingletonScope();
 container.bind(TYPES.FileSystemService).to(FileSystemService).inSingletonScope();
+container.bind(TYPES.BlobStorageService).to(BlobStorageService).inSingletonScope();
 container.bind<ICommand>(TYPES.Command).to(ClipImgCommand);
 //container.bind<ICommand>(TYPES.Command).to(UploadToAzureCommand);
 container.bind<CommandManager>(TYPES.CommandManager).to(CommandManager);

--- a/src/message-service.ts
+++ b/src/message-service.ts
@@ -10,7 +10,7 @@ export class MessageService {
   showWarning(message: string) {
     vscode.window.showWarningMessage(message);
   }
-  
+
   async showQuestion(message: string, options: string): Promise<string | undefined> {
     return await vscode.window.showWarningMessage(message, options);
   }
@@ -19,10 +19,12 @@ export class MessageService {
     vscode.window.showErrorMessage(message);
   }
 
-  async showInput(placeHolder: string, value: string): Promise<any> {
+  async showInput(placeHolder: string, value: string, password: boolean = false): Promise<any> {
     return await vscode.window.showInputBox({
       placeHolder: placeHolder,
-      value: value
+      value: value,
+      ignoreFocusOut: true,
+      password: password
     });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,8 @@ const TYPES = {
   CommandManager: Symbol("CommandManager"),
   MessageService: Symbol("MessageService"),
   ClipboardService: Symbol("ClipboardService"),
-  FileSystemService: Symbol("FileSystemService")
+  FileSystemService: Symbol("FileSystemService"),
+  BlobStorageService: Symbol("BlobStorageService")
 };
 
 export default TYPES;


### PR DESCRIPTION
Still work in progress but will
* upload to azure blob storage
* create a sas token (so container can be private, but image be accessible)
* remove temporary local image

Default container is `clipimg-vscode`, but it can be configured through setting `clipImg.storageAccountContainer`, this maybe should be asked for too.

Storage account will be stored in workspace settings and storage key will be stored securely using [keytar](https://github.com/atom/node-keytar) which on macOS the passwords are managed by the Keychain, on Linux they are managed by the Secret Service API/libsecret, and on Windows they are managed by Credential Vault.

First time command is executing in a workspace it'll ask for storage account name and key (if key not already in credential store).